### PR TITLE
Added new Templates for Navigation and Translator (Merge from UserInterface)

### DIFF
--- a/swac/components/Navigation/Navigation.js
+++ b/swac/components/Navigation/Navigation.js
@@ -29,6 +29,16 @@ export default class Navigation extends View {
             style: 'sitemap',
             desc: 'Simple sitemap generated from the navigation data.'
         };
+		this.desc.templates[3] = {
+            name: 'nav_title_offcanvas',
+            style: 'nav_title_offcanvas',
+            desc: 'Banner displaying a Logo on the left, an Application Name in the Center and the Navigation along its Add-Ons in an Offcanvas Container to the right. Awaits the logo.png in ../../data; AppName configurable using the swac_lang Key appName'
+        };
+		this.desc.templates[4] = {
+            name: 'nav_imagePerItem',
+            style: 'nav_imagePerItem',
+            desc: 'Navigation displaying an Image per Item; img src must be specified using Key src in the displayed Data'
+        };
         this.desc.styles[0] = {
             selc: ".swac_navigation_head",
             desc: "Makes the navigation a head navigation that stays sticky in its position on scrolling."

--- a/swac/components/Navigation/nav_imagePerItem.html
+++ b/swac/components/Navigation/nav_imagePerItem.html
@@ -1,0 +1,7 @@
+<div class="uk-position-fixed uk-position-bottom uk-width-1-1 uk-flex uk-flex-center">
+	<div class="swac_repeatForSet uk-flex uk-width-1-1">
+		<a href="{rto}">
+			<img class="uk-padding-small" src="{src}" alt="{name}">
+		</a>
+	</div>
+</div>

--- a/swac/components/Navigation/nav_title_offcanvas.html
+++ b/swac/components/Navigation/nav_title_offcanvas.html
@@ -1,0 +1,41 @@
+<nav id="header" swa="Navigation FROM routes.json">
+	<div class="uk-offcanvas-content">
+		<nav uk-navbar>
+			<div class="uk-navbar-left">
+				<a class="uk-navbar-item uk-logo" href="index.html">
+					<img class="uk-margin-left" src="../../files/icons/logo.png" alt="Logo" style="width: 70px;">
+				</a>
+			</div>
+			<div class="uk-navbar-center">
+				<h1 class="uk-text-light uk-margin-remove" swac_lang="appName"></h1>
+			</div>
+			<div class="uk-navbar-right">
+				<a class="uk-margin-right uk-navbar-item" href="#offcanvas-nav" uk-toggle>
+					<span uk-navbar-toggle-icon></span>
+				</a>
+			</div>
+		</nav>
+		<div id="offcanvas-nav" uk-offcanvas="overlay: true; flip: true">
+			<div class="uk-offcanvas-bar">
+				<div class="uk-flex uk-flex-column uk-margin-bottom">
+					<span class="uk-margin-bottom" swac_lang="app.lang"></span>
+					<span class="swac_nav_addons"></span>
+				</div>
+				<div class="uk-flex uk-flex-column uk-margin-bottom">
+					<span class="uk-margin-bottom" swac_lang="app.sites"></span>
+					<ul class="uk-nav uk-nav-default">
+						<li class="swac_nav_addons_mob">
+						</li>
+						<li class="swac_repeatForSet">
+							<a href="{rto}" swac_id="{id}" swac_parent="{parent}" swac_lang="{name}"></a>
+							<ul class="uk-nav-sub swac_forChilds">
+								<li class="swac_child"><a href="{rto}" swac_lang="{name}">{name}</a></li>
+							</ul>
+							<hr class="">
+						</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	</div>
+</nav>

--- a/swac/components/Translator/Translator.js
+++ b/swac/components/Translator/Translator.js
@@ -15,6 +15,10 @@ export default class Translator extends View {
             name: 'translatetools',
             desc: 'Template with tools for translation.'
         };
+		this.desc.templates[1] = {
+            name: 'translatetools_unsized',
+            desc: 'Template with tools for translation. No Size Restricitons'
+        };
         this.desc.reqPerTpl[0] = {
             selc: '.swac_translator_lngsel',
             desc: 'Language selection element'

--- a/swac/components/Translator/translatetools_unsized.html
+++ b/swac/components/Translator/translatetools_unsized.html
@@ -1,0 +1,3 @@
+<select class="swac_translator_lngsel uk-select">
+	<option class="swac_dontdisplay"></option>
+</select>


### PR DESCRIPTION
Two new Templates for Navigation
- nav_title_offcanvas
  main navigation along plugins in an offcanvas element. Logo plus via swac_lang configurable Title present.

- nav_imagePerItem
  displays each item using an image reading it from data being displayed.

One new Template for Translator
- translatetools_unsized
  removed uk-form-width-small and uk-form-small classes as to not restrict its width.
  